### PR TITLE
Fix dispatchToast

### DIFF
--- a/src/FS.FluentUI/FluentUI.fs
+++ b/src/FS.FluentUI/FluentUI.fs
@@ -84,8 +84,9 @@ type [<Erase>] Fui =
 
         {
             dispatchToast = fun (element, options) ->
-                let args = element, (!!options |> createObj |> unbox<DispatchToastOptions>)
-                args |> JSTuple.from2Args |> controller.dispatchToast
+                let options = !!options |> createObj |> unbox<DispatchToastOptions>
+                emitJsExpr (element, options) "$0, $1"
+                |> controller.dispatchToast
             dismissToast = fun props -> controller.dismissToast props
             dismissAllToasts = fun props -> controller.dismissAllToasts props
             updateToast = fun props -> !!props |> createObj |> unbox |> controller.updateToast


### PR DESCRIPTION
### Fix issue where bundling with vite would break dispatchToast

Using an intermediary 'args' tuple for the input arguments of the `dispatchToast` function on the ToastController lead to a broken function call after bundling for production with vite, resulting in runtime errors on dispatching a toast.

This PR proposes to instead emit the arguments directly into the function call to resolve this.

#### The resulting JS diff:
Following is the diff in the resulting javascript expression after it has been compiled and bundled/optimized by vite, and the first snippet produces a runtime error.

Before:
```javascript
    toastController = (new ToastController((props_2) => {
        let args_1;
        const tupledArg = props_2;
        controller.dispatchToast((args_1 = [tupledArg[0], createObj(tupledArg[1])], args_1[0], args_1[1]));
    },

```

After:
```javascript
    toastController = (new ToastController((tupledArg) => {
        const options_1 = createObj(tupledArg[1]);
        controller.dispatchToast(tupledArg[0], options_1);
    },
```


Closes #9 