### PR TITLE
Add missing tableCellActions overload

### DIFF
--- a/src/FS.FluentUI/FluentUI.fs
+++ b/src/FS.FluentUI/FluentUI.fs
@@ -740,6 +740,7 @@ type [<Erase>] Fui =
     static member inline tableCellLayout (props: ReactElement list) = Interop.reactElementWithChildren (import "TableCellLayout" FluentUIv9) props
     static member inline tableCellLayout (props: ITableCellLayoutProp list) = createElement (import "TableCellLayout" FluentUIv9) props
     static member inline tableCellActions (props: ReactElement list) = Interop.reactElementWithChildren (import "TableCellActions" FluentUIv9) props
+    static member inline tableCellActions (props: ITableCellActionsProp list) = createElement (import "TableCellActions" FluentUIv9) props
     static member inline tableResizeHandle (props: ITableResizeHandleProp list) = createElement (import "TableResizeHandle" FluentUIv9) props
 
     // DataGrid


### PR DESCRIPTION
Wanted to sett tableCellActions key, but it wouldn't let me. So just added the missing overload :)