### PR TITLE
Add box-shadow overload

### DIFF
--- a/src/FS.FluentUI.TestGrounds/src/TestGrounds.fs
+++ b/src/FS.FluentUI.TestGrounds/src/TestGrounds.fs
@@ -40,6 +40,8 @@ type Styles = {
     swatchExample: string
     swatchButton: string
     swatchInput: string
+    boxShadow: string
+    boxShadowOverloaded: string
 }
 
 let useStyles =
@@ -151,6 +153,14 @@ let useStyles =
         [
             style.display.block
             style.margin (length.px 10)
+        ]
+        "boxShadow",
+        [
+            style.boxShadow (1,1,"black")
+        ]
+        "boxShadowOverloaded",
+        [
+            style.boxShadow Theme.tokens.shadow4
         ]
     ]
 
@@ -4264,6 +4274,20 @@ let NavTest () =
         ]
     ]
 
+[<ReactComponent>]
+let BoxShadow () =
+    let styles = useStyles ()
+    Html.div [
+        Fui.button [
+            button.text "Std BoxShadow"
+            button.className styles.boxShadow
+        ]
+        Fui.button [
+            button.text "Overloaded BoxShadow"
+            button.className styles.boxShadowOverloaded
+        ]
+    ]
+
 let mainContent model dispatch =
 
     // findIconsWithoutFilledOrRegularVersions IconsToTest.icons
@@ -4302,6 +4326,7 @@ let mainContent model dispatch =
                     ]
                 ]
             ]
+            BoxShadow ()
             NavTest ()
             CarouselTest()
             PresenceComponentTest()

--- a/src/FS.FluentUI/FelizProps.fs
+++ b/src/FS.FluentUI/FelizProps.fs
@@ -11,6 +11,9 @@ open System
 open Feliz
 open FS.FluentUI
 
+/// Overload that allows boxShadow styles to accept boxshadow tokens in FS.FluentUI
+type style with static member inline boxShadow ( value : string ) = Interop.mkStyle "box-shadow" value
+
 /// Represents the native Html properties.
 [<Erase>]
 type prop<'Property> =

--- a/src/FS.FluentUI/FelizProps.fs
+++ b/src/FS.FluentUI/FelizProps.fs
@@ -11,9 +11,6 @@ open System
 open Feliz
 open FS.FluentUI
 
-/// Overload that allows boxShadow styles to accept boxshadow tokens in FS.FluentUI
-type style with static member inline boxShadow ( value : string ) = Interop.mkStyle "box-shadow" value
-
 /// Represents the native Html properties.
 [<Erase>]
 type prop<'Property> =

--- a/src/FS.FluentUI/FluentUI.fs
+++ b/src/FS.FluentUI/FluentUI.fs
@@ -7,6 +7,11 @@ open Feliz
 open FS.FluentUI
 open System
 
+[<AutoOpen>]
+module FelizOverloads =
+    /// Overload that allows boxShadow styles to accept boxshadow tokens in FS.FluentUI
+    type style with static member inline boxShadow ( value : string ) = Interop.mkStyle "box-shadow" value
+
 module internal Shorthand =
 
     let expand (style): obj = import "expand" "./inline-style-expand-shorthand.js"

--- a/src/FS.FluentUI/Utils.fs
+++ b/src/FS.FluentUI/Utils.fs
@@ -258,9 +258,6 @@ type [<Erase>] IAppItemStaticProp = interface end
 type [<Erase>] ISplitNavItemProp = interface end
 type [<Erase>] INavDrawerFooterProp = interface end
 
-type [<AllowNullLiteral; Erase>] IStyle = interface end
-type [<AllowNullLiteral; Erase>] ITheme = interface end
-
 type [<AllowNullLiteral; Erase>] BundleIcon = interface end
 
 type [<RequireQualifiedAccess>] BundleIcons = { Filled: BundleIcon; Regular: BundleIcon }


### PR DESCRIPTION
Theme tokens for boxshadow are unusable as it stands because the style prop does not accept a string.

This adds an overload to allow this behaviour.

The boxshadow styles would still need to be used by Fui.makeStyles.