### PR TITLE
Add appearance to breadcrumbButton

### DIFF
--- a/src/FS.FluentUI.TestGrounds/src/TestGrounds.fs
+++ b/src/FS.FluentUI.TestGrounds/src/TestGrounds.fs
@@ -2972,6 +2972,7 @@ let RenderButton (button: ButtonItem) (isLastItem: bool) =
                         yield! button.buttonProps
                         breadcrumbButton.current isLastItem
                         breadcrumbButton.text button.item
+                        breadcrumbButton.appearance.subtle
                     ]
                 ]
             )

--- a/src/FS.FluentUI/Props2.fs
+++ b/src/FS.FluentUI/Props2.fs
@@ -1863,7 +1863,7 @@ type [<Erase>] breadcrumbButton =
     static member inline icon (value: IReactProperty list) = Interop.mkProperty<IBreadcrumbButtonProp> "icon" (!!value |> createObj |> unbox<IReactProperty>)
     /// Icon that renders either before or after the `children` as specified by the `iconPosition` prop.
     static member inline icon (value: ReactElement) = Interop.mkProperty<IBreadcrumbButtonProp> "icon" value
-    /// Defines current sate of BreadcrumbButton.
+    /// Defines current state of BreadcrumbButton.
     static member inline current (value: bool) = Interop.mkProperty<IBreadcrumbButtonProp> "current" value
     /// When set, allows the button to be focusable even when it has been disabled.
     /// This is used in scenarios where it is important to keep a consistent tab order for screen reader and keyboard users.
@@ -1877,6 +1877,19 @@ module breadcrumbButton =
     type [<Erase>] as' =
         static member inline a = Interop.mkProperty<IBreadcrumbButtonProp> "as" "a"
         static member inline button = Interop.mkProperty<IBreadcrumbButtonProp> "as" "button"
+
+    /// A breadcrumbButton can have its content and borders styled for greater emphasis or to be subtle.
+    type [<Erase>] appearance =
+        /// 'subtle' (default): Minimizes emphasis to blend into the background until hovered or focused.
+        static member inline subtle = Interop.mkProperty<IBreadcrumbButtonProp> "appearance" "subtle"
+        /// 'outline': Removes background styling.
+        static member inline outline = Interop.mkProperty<IBreadcrumbButtonProp> "appearance" "outline"
+        /// 'secondary': Gives emphasis to the button in such a way that it indicates a secondary action.
+        static member inline secondary = Interop.mkProperty<IBreadcrumbButtonProp> "appearance" "secondary"
+        /// 'primary': Emphasizes the button as a primary action.
+        static member inline primary = Interop.mkProperty<IBreadcrumbButtonProp> "appearance" "primary"
+        /// 'transparent': Removes background and border styling.
+        static member inline transparent = Interop.mkProperty<IBreadcrumbButtonProp> "appearance" "transparent"
 
     /// Controls size of Breadcrumb items and dividers.
     type [<Erase>] size =


### PR DESCRIPTION
Hi Andrew,

I added `appearance` to `breadcrumbButton`. 
While this isn't strictly mentioned in the storybook, it works quite well so I figured it may be useful to share.
Totally understandable if you'd rather not introduce non-official props though!

![image](https://github.com/user-attachments/assets/8867da2a-f3a0-42f4-ba31-71fe5b4415b8)

All the best,

Rob