### PR TITLE
Add string menuitem subtext and fixed spellCheck property

### DIFF
--- a/src/FS.FluentUI.TestGrounds/src/TestGrounds.fs
+++ b/src/FS.FluentUI.TestGrounds/src/TestGrounds.fs
@@ -4930,8 +4930,8 @@ let mainContent model dispatch =
         ]
         stack.horizontalAlign.center
         stack.children [
-            //ColorPickerTest ()
-            //FullCalendar()
+            ColorPickerTest ()
+            FullCalendar()
             // Html.div [
             //     prop.style [
             //         style.height 200

--- a/src/FS.FluentUI.TestGrounds/src/TestGrounds.fs
+++ b/src/FS.FluentUI.TestGrounds/src/TestGrounds.fs
@@ -392,6 +392,7 @@ let MenuTest () =
                                         Fui.menuItem [
                                             menuItem.compact
                                             menuItem.text "In Mobile"
+                                            menuItem.subText "This is some subtext"
                                         ]
                                     ]
                                 ]
@@ -4929,8 +4930,8 @@ let mainContent model dispatch =
         ]
         stack.horizontalAlign.center
         stack.children [
-            ColorPickerTest ()
-            FullCalendar()
+            //ColorPickerTest ()
+            //FullCalendar()
             // Html.div [
             //     prop.style [
             //         style.height 200
@@ -4971,7 +4972,7 @@ let mainContent model dispatch =
             // ToggleButtons()
             // buttonTest
             // menuButtonTest
-            // MenuTest()
+            MenuTest()
             // imageTest
             // presenceBadgeTest
             // counterBadge
@@ -5022,7 +5023,7 @@ let mainContent model dispatch =
             // UseFocusFindersTest()
             // UseModalAttributesOptionsTest()
             // fieldPropsTest
-            BreadcrumbTest()
+            // BreadcrumbTest()
             // SearchBoxTest()
             // TagTest()
             // InteractionTagTest()

--- a/src/FS.FluentUI/FelizProps.fs
+++ b/src/FS.FluentUI/FelizProps.fs
@@ -1546,7 +1546,7 @@ type prop<'Property> =
     static member inline span (value: int) = Interop.mkProperty<'Property> "span" value
 
     /// Defines whether the element may be checked for spelling errors.
-    static member inline spellcheck (value: bool) = Interop.mkProperty<'Property> "spellcheck" (string value)
+    static member inline spellcheck (value: bool) = Interop.mkProperty<'Property> "spellCheck" (string value)
 
     /// Controls the ratio of reflection of the specular lighting.
     ///

--- a/src/FS.FluentUI/Props.fs
+++ b/src/FS.FluentUI/Props.fs
@@ -1092,6 +1092,8 @@ type [<Erase>] menuItem =
     static member inline subText (value: ReactElement) = Interop.mkProperty<IMenuItemProp> "subText" value
     /// Additional descriptor to main content that creates a multiline layout
     static member inline subText (value: IReactProperty list) = Interop.mkProperty<IMenuItemProp> "subText" (!!value |> createObj |> unbox)
+    /// Additional descriptor to main content that creates a multiline layout
+    static member inline subText (value : string) = Interop.mkProperty "subText" value
     /// If the menu item is a trigger for a submenu
     static member inline hasSubmenu (value: bool) = Interop.mkProperty<IMenuItemProp> "hasSubmenu" value
     /// Clicking on the menu item will not dismiss an open menu


### PR DESCRIPTION
Hi Andrew,

Wanted to share some very minor stuff I had modified in my project.

- Added a string subtext prop for menuItem. 

<img width="385" height="149" alt="image" src="https://github.com/user-attachments/assets/71c4aba7-68b4-42f9-b5db-5ce167c6908f" />

- Updated `spellcheck` to `spellCheck` for it to be picked up properly.


Hope this help!

All the best,

Rob

