### PR TITLE
Add createFluentIcon support

### DIFF
--- a/src/FS.FluentUI/FluentUI.fs
+++ b/src/FS.FluentUI/FluentUI.fs
@@ -1194,18 +1194,9 @@ module Fui =
             fun (props: IIconProp list) -> createElement icon props
 
         /// Use this function to create new icons from SVG paths. <br/>
-        /// See <link>https://github.com/microsoft/fluentui-system-icons/blob/main/packages/react-icons/src/utils/createFluentIcon.ts</link.
-        ///
-        /// Example:
-        /// <code>
-        /// type [<Erase>] CustomIcons =
-        ///     static member inline microsoft (props : IIconProp list) =
-        ///         createElement (Fui.icon.createIconType("microsoft", "1em", [|
-        ///             "M1.0 1.0h7.5v7.5H1.0V1.0m9.0 0.0h7.5v7.5h-7.5V1.0m-9.0 9.0h7.5v7.5H1.0v-7.5m9.0 0.0h7.5v7.5h-7.5v-7.5"
-        ///         |])) props
-        /// </code>
-        [<Import("createFluentIcon", FluentIcons)>]
-        static member inline createIconType(displayName : string, width : string, paths : string array) : ReactElementType = jsNative
+        /// See <link>https://github.com/microsoft/fluentui-system-icons/blob/main/packages/react-icons/src/utils/createFluentIcon.ts</link>.
+        static member inline createFluentIcon (displayName : string, width : string, paths : string array) : ReactElementType =
+            JSTuple.from3Args (displayName, width, paths) |> import "createFluentIcon" FluentIcons
         static member inline xrayRegular (props: IIconProp list) = createElement (import "XrayRegular" FluentIcons) props
         static member inline xrayFilled (props: IIconProp list) = createElement (import "XrayFilled" FluentIcons) props
         static member inline usbStickRegular (props: IIconProp list) = createElement (import "UsbStickRegular" FluentIcons) props

--- a/src/FS.FluentUI/FluentUI.fs
+++ b/src/FS.FluentUI/FluentUI.fs
@@ -6873,4 +6873,3 @@ module Fui =
         static member inline backpackAddFilled (props: IIconProp list) = createElement (import "BackpackAddFilled" FluentIcons) props
         static member inline backpackRegular (props: IIconProp list) = createElement (import "BackpackRegular" FluentIcons) props
         static member inline backpackFilled (props: IIconProp list) = createElement (import "BackpackFilled" FluentIcons) props
-

--- a/src/FS.FluentUI/FluentUI.fs
+++ b/src/FS.FluentUI/FluentUI.fs
@@ -1192,6 +1192,20 @@ module Fui =
         static member inline import (iconName: string) =
             let icon = import $"{iconName}" FluentIcons
             fun (props: IIconProp list) -> createElement icon props
+
+        /// Use this function to create new icons from SVG paths. <br/>
+        /// See <link>https://github.com/microsoft/fluentui-system-icons/blob/main/packages/react-icons/src/utils/createFluentIcon.ts</link.
+        ///
+        /// Example:
+        /// <code>
+        /// type [<Erase>] CustomIcons =
+        ///     static member inline microsoft (props : IIconProp list) =
+        ///         createElement (Fui.icon.createIconType("microsoft", "1em", [|
+        ///             "M1.0 1.0h7.5v7.5H1.0V1.0m9.0 0.0h7.5v7.5h-7.5V1.0m-9.0 9.0h7.5v7.5H1.0v-7.5m9.0 0.0h7.5v7.5h-7.5v-7.5"
+        ///         |])) props
+        /// </code>
+        [<Import("createFluentIcon", FluentIcons)>]
+        static member inline createIconType(displayName : string, width : string, paths : string array) : ReactElementType = jsNative
         static member inline xrayRegular (props: IIconProp list) = createElement (import "XrayRegular" FluentIcons) props
         static member inline xrayFilled (props: IIconProp list) = createElement (import "XrayFilled" FluentIcons) props
         static member inline usbStickRegular (props: IIconProp list) = createElement (import "UsbStickRegular" FluentIcons) props
@@ -6868,3 +6882,4 @@ module Fui =
         static member inline backpackAddFilled (props: IIconProp list) = createElement (import "BackpackAddFilled" FluentIcons) props
         static member inline backpackRegular (props: IIconProp list) = createElement (import "BackpackRegular" FluentIcons) props
         static member inline backpackFilled (props: IIconProp list) = createElement (import "BackpackFilled" FluentIcons) props
+


### PR DESCRIPTION
Hey Andrew,

This PR adds a binding to 'createFluentIcon`. (https://github.com/microsoft/fluentui-system-icons/blob/main/packages/react-icons/src/utils/createFluentIcon.ts)

It allows you to define your own icons based on SVG paths as such:

```fsharp
type [<Erase>] CustomIcons =
    static member inline microsoft (props : IIconProp list) =
        createElement (Fui.icon.createIconType("microsoft", "1em", [|
            "M1.0 1.0h7.5v7.5H1.0V1.0m9.0 0.0h7.5v7.5h-7.5V1.0m-9.0 9.0h7.5v7.5H1.0v-7.5m9.0 0.0h7.5v7.5h-7.5v-7.5"
        |])) props
```

The icon is then available to be used and customized like any other icon that is already available in the catalog.
Example usage:
```fsharp
navItem.icon (CustomIcons.microsoft [icon.size.``20``])
```

<img width="261" height="85" alt="image" src="https://github.com/user-attachments/assets/c64650e5-cab8-4fdd-a07c-5dfd010f30b4" />


I just threw this function in `Fui.icon` but if you'd prefer it to be located somewhere else I'd be happy to move it around!
For the comments I tried to stay consistent with `import`.

Let me know what you think!

Have a nice day,

Rob