### PR TITLE
Add @fluentui/react-charts ResponsiveContainer

### DIFF
--- a/src/FS.FluentUI.Charts/Charts.fs
+++ b/src/FS.FluentUI.Charts/Charts.fs
@@ -34,4 +34,5 @@ type Fui =
                         let args = color, isDarkTheme
                         import "getColorFromToken" "@fluentui/react-charts" (emitJsExpr args "$0[0], $0[1]")
     static member inline legends (props: ILegendsProp list) = Helpers.createElement (import "Legends" "@fluentui/react-charts") props
+    static member inline responsiveContainer (props : IResponsiveContainerProp list) = Helpers.createElement (import "ResponsiveContainer" "@fluentui/react-charts") props
 

--- a/src/FS.FluentUI.Charts/Props.fs
+++ b/src/FS.FluentUI.Charts/Props.fs
@@ -3970,3 +3970,15 @@ module polarChart =
         static member inline clockwise = Interop.mkProperty<IPolarChartProp> "direction" "clockwise"
         /// Direction in which the chart is drawn.
         static member inline counterclockwise = Interop.mkProperty<IPolarChartProp> "direction" "counterclockwise"
+
+
+// ------------------------------------------------------------- ResponsiveContainer ------------------------------------------
+
+type [<Erase>] responsiveContainer =
+    static member inline aspect (value: float) = Interop.mkProperty<IResponsiveContainerProp> "aspect" value
+    static member inline children (value: ReactElement) = Interop.mkProperty<IResponsiveContainerProp> "children" value
+    static member inline children (values: ReactElement seq) = Interop.mkProperty<IResponsiveContainerProp> "children" values
+    static member inline height (value: int) = Interop.mkProperty<IResponsiveContainerProp> "height" value
+    static member inline minWidth (value: int) = Interop.mkProperty<IResponsiveContainerProp> "minWidth" value
+    static member inline minHeight (value: int) = Interop.mkProperty<IResponsiveContainerProp> "minHeight" value
+    static member inline width (value: int) = Interop.mkProperty<IResponsiveContainerProp> "width" value

--- a/src/FS.FluentUI.Charts/Utils.fs
+++ b/src/FS.FluentUI.Charts/Utils.fs
@@ -106,3 +106,4 @@ type [<Erase>] IScatterPolarSeriesProp = interface end
 type [<Erase>] IPolarChartStylesProp = interface end
 type [<Erase>] IPolarAxisProp = interface end
 type [<Erase>] IAxisProp = interface end
+type [<Erase>] IResponsiveContainerProp = interface end

--- a/src/FS.FluentUI.TestGrounds/src/TestCharts.fs
+++ b/src/FS.FluentUI.TestGrounds/src/TestCharts.fs
@@ -837,7 +837,10 @@ let polarChartData = [
 let TestChartsComponent () =
     let sliderValue, setSliderValue = React.useState 50
     Html.div [
-        prop.style [ style.width 1000; style.margin 36 ]
+        prop.style [
+            style.width (length.perc 100)
+            style.margin 36
+        ]
         prop.children [
             Fui.polarChart [
                 polarChart.data polarChartData
@@ -845,6 +848,33 @@ let TestChartsComponent () =
                 polarChart.height 300
                 polarChart.shape.polygon
                 polarChart.direction.clockwise
+            ]
+            Fui.responsiveContainer [
+                responsiveContainer.children [
+
+                    Fui.areaChart [
+                        areaChart.mode.tonexty
+                        areaChart.height 300
+                        areaChart.width 600
+                        areaChart.legendsOverflowText "Overflow Items"
+                        areaChart.yAxisTickFormat (fun (s:string) -> "$" + s)
+                        areaChart.svgProps [ prop.ariaLabel "This is another test?!"]
+                        areaChart.enableGradient true
+                        areaChart.enablePerfOptimization true
+                        areaChart.reflowProps.modeNone
+                        areaChart.xAxis.tickStep 5
+                        areaChart.xAxis.tick0 5
+                        areaChart.legendProps [
+                            legends.allowFocusOnLegends true
+                            legends.canSelectMultipleLegends true
+                            legends.centerLegends true
+                        ]
+                        areaChart.data [
+                            chart.chartTitle "Areachart in responsive container"
+                            chart.lineChartData areaChartDataList
+                        ]
+                    ]
+                ]
             ]
             Fui.areaChart [
                 areaChart.mode.tonexty


### PR DESCRIPTION
Hey Andrew,

After dabbling with the charts I've found that there is a `ResponsiveContainer` inside the official package.
It is built to wrap a chart element and handle resize events.
This pull requests adds this container and its props.

Attached is a GIF of the testbed showing a chart that is wrapped (above) vs a chart that is not (below).
As you can see the unwrapped chart needs a 'hover' event to trigger a redraw.

<img width="1231" height="942" alt="chart_wrapper" src="https://github.com/user-attachments/assets/36f03a48-6763-4772-9f94-1acfaa11147d" />



Happy to hear your thoughts!

PS. I've been running the 4.0.0-prerelease-003 for a while now I think it may be ready for the real world :)